### PR TITLE
Fix dataset path in RBM notebook

### DIFF
--- a/RBM.ipynb
+++ b/RBM.ipynb
@@ -40,7 +40,7 @@
         "outputId": "72a0bee7-89c2-43ad-ef77-2c2cb96bb05f"
       },
       "source": [
-        "df = pd.read_csv(\"/content/index.csv\")\n",
+        "df = pd.read_csv(\"index.csv\")\n",
         "df.head()"
       ],
       "execution_count": null,


### PR DESCRIPTION
## Summary
- fix incorrect dataset path in `RBM.ipynb`

## Testing
- `python -m json.tool RBM.ipynb >/dev/null`

------
https://chatgpt.com/codex/tasks/task_e_688432ebf6748322bf758903ad367713